### PR TITLE
Multiple PDF File protocol

### DIFF
--- a/simple_signer/simple_signer.py
+++ b/simple_signer/simple_signer.py
@@ -25,6 +25,25 @@ from PyQt5.QtGui import *
 from PyQt5.QtCore import *
 from locale import getdefaultlocale
 
+class FileDropLineEdit(QLineEdit):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setAcceptDrops(True)
+        self.setPlaceholderText(QApplication.translate('SimpleSigner','Drag and drop a file here...'))
+        
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+            
+    def dropEvent(self, event):
+        if event.mimeData().hasUrls():
+            file_path = event.mimeData().urls()[0].toLocalFile()
+            self.setText(file_path)
+            event.acceptProposedAction()
+        else:
+            event.ignore()
 
 class SimpleSignerAboutWindow(QDialog):
 	def __init__(self, *args, **kwargs):
@@ -257,7 +276,7 @@ class SimpleSignerMainWindow(QMainWindow):
 
 		self.lblPdfPath = QLabel(QApplication.translate('SimpleSigner', 'PDF File'))
 		grid.addWidget(self.lblPdfPath, 0, 0)
-		self.txtPdfPath = QLineEdit()
+		self.txtPdfPath = FileDropLineEdit()
 		grid.addWidget(self.txtPdfPath, 1, 0)
 		self.btnChoosePdfPath = QPushButton(QApplication.translate('SimpleSigner', 'Choose...'))
 		self.btnChoosePdfPath.clicked.connect(self.OnClickChoosePdfPath)

--- a/simple_signer/simple_signer.py
+++ b/simple_signer/simple_signer.py
@@ -318,6 +318,8 @@ class SimpleSignerMainWindow(QMainWindow):
 		self.singleFileWidget.setLayout(singleFileLayout)
 		mainLayout.addWidget(self.singleFileWidget)
 
+		self.btnChoosePdfPath.clicked.connect(self.OnClickChoosePdfPath)
+		
 		# Multiple Files Selection Widgets
 		self.multipleFilesWidget = QWidget()
 		multipleFilesLayout = QVBoxLayout()
@@ -334,6 +336,8 @@ class SimpleSignerMainWindow(QMainWindow):
 		self.multipleFilesWidget.setLayout(multipleFilesLayout)
 		mainLayout.addWidget(self.multipleFilesWidget)
 		self.multipleFilesWidget.hide()
+
+		self.btnChoosePdfFolder.clicked.connect(self.OnClickChoosePdfFolder)
 
 		# Connect radio buttons to handlers
 		# updateFileSelectionMode() and updateFileActions() are defined below


### PR DESCRIPTION
This sorts #19 feature requested by me in #16 

Ideally, this should be merged after #23 because it includes this PR, I've added it because otherwise it will provoke a merging conflict

1. Conditionally controls the possibility to add a single file or a folder 
2. It also controls the Menu item visibility to add a file or a folder
3. I have redesigned a little the interface, using Layouts instead of Grids, which is much simpler to track (grids can be a pain to track in the head for such a simple layout used in this app)
4. I have reformulated some signing functions to modularize them to simplify the multiple signing function.

### Future considerations: 
I don't love how multiple signing is currently done because it's asking signing one file at a time as if it's a single file signing protocol, repeated multiple times, so it will throw a prompt per file signed, which is not terrible, but I would prefer it fully automated all at once, without prompts in between (at best just a prompt in the end to display just the folder where all the PDF have been generated). It could be achieved by simply passing a parameter to `DoSign` to pass the success message or not accordingly.

Although for now, it's functional. I've only tested on Windows. 