### PR TITLE
Using OS Lang instead of Locale

### DIFF
--- a/simple_signer/simple_signer.py
+++ b/simple_signer/simple_signer.py
@@ -25,7 +25,6 @@ if os.environ.get('QT_QPA_PLATFORMTHEME') == 'qt5ct':
 from PyQt5.QtWidgets import *
 from PyQt5.QtGui import *
 from PyQt5.QtCore import *
-from locale import getlocale
 
 
 class SimpleSignerAboutWindow(QDialog):
@@ -568,15 +567,14 @@ class SimpleSignerMainWindow(QMainWindow):
 def get_os_language():
     if os.name == 'nt':
         windll = ctypes.windll.kernel32
-        windll.GetUserDefaultUILanguage()
-        return locale.windows_locale[ windll.GetUserDefaultUILanguage() ]
+        return locale.windows_locale[ windll.GetUserDefaultUILanguage() ][0:2]
     else:
-        return os.environ['LANG']
+        return locale.getlocale()[0][0:2]
 
 def main():
 	app = QApplication(sys.argv)
 	translator = QTranslator(app)
-	langCode = get_os_language()[0:2]
+	langCode = get_os_language()
 	if getattr(sys, 'frozen', False):
 		translator.load(os.path.join(sys._MEIPASS, 'lang/%s.qm' % langCode))
 	elif os.path.isdir('lang'):

--- a/simple_signer/simple_signer.py
+++ b/simple_signer/simple_signer.py
@@ -9,6 +9,8 @@ import subprocess
 import configparser
 import json
 import traceback
+import ctypes
+import locale
 from pathlib import Path
 from shutil import which
 
@@ -563,10 +565,18 @@ class SimpleSignerMainWindow(QMainWindow):
 	def existsBinary(self, name):
 		return which(name) is not None
 
+def get_os_language():
+    if os.name == 'nt':
+        windll = ctypes.windll.kernel32
+        windll.GetUserDefaultUILanguage()
+        return locale.windows_locale[ windll.GetUserDefaultUILanguage() ]
+    else:
+        return os.environ['LANG']
+
 def main():
 	app = QApplication(sys.argv)
 	translator = QTranslator(app)
-	langCode = getlocale()[0][0:2]
+	langCode = get_os_language()[0:2]
 	if getattr(sys, 'frozen', False):
 		translator.load(os.path.join(sys._MEIPASS, 'lang/%s.qm' % langCode))
 	elif os.path.isdir('lang'):


### PR DESCRIPTION
I've tested this on Windows and its working correctly. 

It shows as I said in #20 the OS language, not the regional language, which is always preferred (because the regional settings don't have anything to do with the language itself)

But I have not tested in Linux yet. Theorically both in Mac OS and Linux, we have a `LANG` environment variable [1](https://apple.stackexchange.com/questions/21096/where-does-lang-variable-gets-set-in-mac-os-x) that we could query with `os.environ`  [2](https://stackoverflow.com/questions/4906977/how-can-i-access-environment-variables-in-python)

closes #20 