### PR TITLE
fix time on stamp

### DIFF
--- a/simple_signer/simple_signer.py
+++ b/simple_signer/simple_signer.py
@@ -262,7 +262,7 @@ class SimpleSignerMainWindow(QMainWindow):
 	stampOutline      = [0.20, 0.30, 0.50]
 	stampBorder       = 1
 	stampText         = 'Digitally Signed by\n$SUBJECT_CN$\n$TIMESTAMP$'
-	dateFormat        = '%d.%m.%Y %H:%m'
+	dateFormat        = '%d.%m.%Y %H:%M'
 
 	def __init__(self):
 		super(SimpleSignerMainWindow, self).__init__()


### PR DESCRIPTION
The time on the signing stamp was set incorrectly, as the minutes were showing the month instead.
Quick fix in the format to reflect the correct timing.